### PR TITLE
Changing backspace from "⇐" to "⌫"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I've made significant changes, including:
   * `-n, --no-hide` do not hide window after timeout, hide only text (make it
     usable with tile managers, for example, with i3, which can not have
     unfocusable windows);
-* instead of removing text on `backspace` symbol `⇐` will be added; it was
+* instead of removing text on `backspace` symbol `⌫` will be added; it was
   broken anyway, so it will happily erase `Ctrl+...` and other text;
 * space is changed to visible character: `␣`;
 * supported second keyboard layout, so not only ASCII letters can be recorded;

--- a/Screenkey/listenkbd.py
+++ b/Screenkey/listenkbd.py
@@ -52,7 +52,7 @@ REPLACE_KEYS = {
     'XK_Down':u'\u2193',
     'XK_Next':_('PgDn'),
     'XK_Insert':_('Ins'),
-    'XK_BackSpace':_(u'\u21d0'),
+    'XK_BackSpace':_(u'\u232B'),
     'XK_Delete':_('Del'),
     'XK_KP_Home':u'(7)',
     'XK_KP_Up':u'(8)',

--- a/screenkey
+++ b/screenkey
@@ -34,7 +34,7 @@ def main():
     parser = OptionParser(description=APP_DESC, version=VERSION)
     parser.add_option(
         "--no-detach", action="store_true",
-        dest="nodetach", default=True,
+        dest="nodetach", default=False,
         help=_("do not detach from the parent"))
     parser.add_option(
         "-d", "--debug", action="store_true",


### PR DESCRIPTION
I believe ⌫ character (U+232B ERASE TO THE LEFT) is more appropriate to Backspace.

There is also the opposite: ⌦ (U+2326 ERASE TO THE RIGHT); which may be appropriate for "delete" key, but the current "Del" text seems more intuitive.

On a completely unrelated topic… How did you record that animated GIF? It looks clean, without ugly compression artifacts. How did you do it?
