### PR TITLE
Fixing Unicode error and other stuff

### DIFF
--- a/Screenkey/__init__.py
+++ b/Screenkey/__init__.py
@@ -1,7 +1,5 @@
-
 APP_NAME = "Screenkey"
 APP_DESC = _("Screencast your keys")
 APP_URL = 'http://launchpad.net/screenkey'
 VERSION = '0.2'
 AUTHOR = 'Pablo Seminario'
-

--- a/Screenkey/listenkbd.py
+++ b/Screenkey/listenkbd.py
@@ -144,7 +144,7 @@ class ListenKbd(threading.Thread):
 
     def update_text(self, string=None):
         gtk.gdk.threads_enter()
-        if not string is None:
+        if string is not None:
             # TODO: make this configurable
             if string.strip() == 'Ctrl+F1':
                 if self._disabled:

--- a/Screenkey/listenkbd.py
+++ b/Screenkey/listenkbd.py
@@ -26,52 +26,53 @@ MODE_RAW = 0
 MODE_NORMAL = 1
 
 REPLACE_KEYS = {
-    'XK_Escape':_('Esc'),
-    'XK_Tab':u'\u21B9',
-    'XK_Return':u'\u23CE',
-    'XK_Space':u'',
-    'XK_Caps_Lock':_('Caps'),
-    'XK_F1':u'F1',
-    'XK_F2':u'F2',
-    'XK_F3':u'F3',
-    'XK_F4':u'F4',
-    'XK_F5':u'F5',
-    'XK_F6':u'F6',
-    'XK_F7':u'F7',
-    'XK_F8':u'F8',
-    'XK_F9':u'F9',
-    'XK_F10':u'F10',
-    'XK_F11':u'F11',
-    'XK_F12':u'F12',
-    'XK_Home':_('Home'),
-    'XK_Up':u'\u2191',
-    'XK_Page_Up':_('PgUp'),
-    'XK_Left':u'\u2190',
-    'XK_Right':u'\u2192',
-    'XK_End':_('End'),
-    'XK_Down':u'\u2193',
-    'XK_Next':_('PgDn'),
-    'XK_Insert':_('Ins'),
-    'XK_BackSpace':_(u'\u21d0'),
-    'XK_Delete':_('Del'),
-    'XK_KP_Home':u'(7)',
-    'XK_KP_Up':u'(8)',
-    'XK_KP_Prior':u'(9)',
-    'XK_KP_Left':u'(4)',
-    'XK_KP_Right':u'(6)',
-    'XK_KP_End':u'(1)',
-    'XK_KP_Down':u'(2)',
-    'XK_KP_Page_Down':u'(3)',
-    'XK_KP_Begin':u'(5)',
-    'XK_KP_Insert':u'(0)',
-    'XK_KP_Delete':u'(.)',
-    'XK_KP_Add':u'(+)',
-    'XK_KP_Subtract':u'(-)',
-    'XK_KP_Multiply':u'(*)',
-    'XK_KP_Divide':u'(/)',
-    'XK_Num_Lock':u'NumLock',
-    'XK_KP_Enter':u'\u23CE',
+    'XK_Escape': _('Esc'),
+    'XK_Tab': u'\u21B9',
+    'XK_Return': u'\u23CE',
+    'XK_Space': u'',
+    'XK_Caps_Lock': _('Caps'),
+    'XK_F1': u'F1',
+    'XK_F2': u'F2',
+    'XK_F3': u'F3',
+    'XK_F4': u'F4',
+    'XK_F5': u'F5',
+    'XK_F6': u'F6',
+    'XK_F7': u'F7',
+    'XK_F8': u'F8',
+    'XK_F9': u'F9',
+    'XK_F10': u'F10',
+    'XK_F11': u'F11',
+    'XK_F12': u'F12',
+    'XK_Home': _('Home'),
+    'XK_Up': u'\u2191',
+    'XK_Page_Up': _('PgUp'),
+    'XK_Left': u'\u2190',
+    'XK_Right': u'\u2192',
+    'XK_End': _('End'),
+    'XK_Down': u'\u2193',
+    'XK_Next': _('PgDn'),
+    'XK_Insert': _('Ins'),
+    'XK_BackSpace': _(u'\u21d0'),
+    'XK_Delete': _('Del'),
+    'XK_KP_Home': u'(7)',
+    'XK_KP_Up': u'(8)',
+    'XK_KP_Prior': u'(9)',
+    'XK_KP_Left': u'(4)',
+    'XK_KP_Right': u'(6)',
+    'XK_KP_End': u'(1)',
+    'XK_KP_Down': u'(2)',
+    'XK_KP_Page_Down': u'(3)',
+    'XK_KP_Begin': u'(5)',
+    'XK_KP_Insert': u'(0)',
+    'XK_KP_Delete': u'(.)',
+    'XK_KP_Add': u'(+)',
+    'XK_KP_Subtract': u'(-)',
+    'XK_KP_Multiply': u'(*)',
+    'XK_KP_Divide': u'(/)',
+    'XK_Num_Lock': u'NumLock',
+    'XK_KP_Enter': u'\u23CE',
 }
+
 
 class ListenKbd(threading.Thread):
     # Add in a shortcut to disable
@@ -93,7 +94,7 @@ class ListenKbd(threading.Thread):
             'alt': False,
             'capslock': False,
             'meta': False,
-            'super':False
+            'super': False
             }
 
         self.logger.debug("Thread created")
@@ -109,19 +110,19 @@ class ListenKbd(threading.Thread):
             sys.exit(1)
 
         self.ctx = self.record_dpy.record_create_context(
-                0,
-                [record.AllClients],
-                [{
-                        'core_requests': (0, 0),
-                        'core_replies': (0, 0),
-                        'ext_requests': (0, 0, 0, 0),
-                        'ext_replies': (0, 0, 0, 0),
-                        'delivered_events': (0, 0),
-                        'device_events': (X.KeyPress, X.KeyRelease),
-                        'errors': (0, 0),
-                        'client_started': False,
-                        'client_died': False,
-                }])
+            0,
+            [record.AllClients],
+            [{
+                'core_requests': (0, 0),
+                'core_replies': (0, 0),
+                'ext_requests': (0, 0, 0, 0),
+                'ext_replies': (0, 0, 0, 0),
+                'delivered_events': (0, 0),
+                'device_events': (X.KeyPress, X.KeyRelease),
+                'errors': (0, 0),
+                'client_started': False,
+                'client_died': False,
+            }])
 
     def run(self):
         self.logger.debug("Thread started.")
@@ -148,10 +149,10 @@ class ListenKbd(threading.Thread):
             # TODO: make this configurable
             if string.strip() == 'Ctrl+F1':
                 if self._disabled:
-                    self._disabled=False
+                    self._disabled = False
                     self.text = "[ENABLED]"
                 else:
-                    self._disabled=True
+                    self._disabled = True
                     self.text = "[DISABLED]"
             else:
                 self.text = "%s%s" % (self.label.get_text(), string)
@@ -171,8 +172,9 @@ class ListenKbd(threading.Thread):
         # This is not the most efficient way to detect the
         # use of sudo/gksudo but it works.
         if not self.nosudo:
-            sudo_is_running = subprocess.call(['ps', '-C', 'sudo'],
-                        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            sudo_is_running = subprocess.call(
+                ['ps', '-C', 'sudo'],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             if not sudo_is_running:
                 return
 
@@ -189,15 +191,15 @@ class ListenKbd(threading.Thread):
         data = reply.data
         key = []
         while len(data):
-            event, data = rq.EventField(None).parse_binary_value(data,
-                                    self.record_dpy.display, None, None)
+            event, data = rq.EventField(None).parse_binary_value(
+                data, self.record_dpy.display, None, None)
             if event.type in [X.KeyPress, X.KeyRelease]:
                 if self.mode == MODE_NORMAL:
                     key.append(self.key_normal_mode(event))
                 if self.mode == MODE_RAW:
                     key.append(self.key_raw_mode(event))
         if any(key):
-          self.update_text(''.join(k for k in key if k))
+            self.update_text(''.join(k for k in key if k))
 
     def key_normal_mode(self, event):
         key = ''
@@ -205,33 +207,32 @@ class ListenKbd(threading.Thread):
         keysym = self.local_dpy.keycode_to_keysym(event.detail, 0)
 
         if event.detail in self.keymap:
-            key_normal_1, key_shift_1, \
-            key_normal_2, key_shift_2, \
-            key_dead, key_deadshift = self.keymap[event.detail]
+            (key_normal_1, key_shift_1,
+             key_normal_2, key_shift_2,
+             key_dead, key_deadshift) = self.keymap[event.detail]
             if event.state & 1 << 13 != 0:
                 key_normal = key_normal_2
                 key_shift = key_shift_2
             else:
                 key_normal = key_normal_1
                 key_shift = key_shift_1
-            self.logger.debug("Key %s(keycode) %s. Symbols %s" %
-                (event.detail,
-                 event.type == X.KeyPress and "pressed" or "released",
-                 self.keymap[event.detail])
-                )
+            self.logger.debug("Key %s(keycode) %s. Symbols %s" % (
+                event.detail,
+                event.type == X.KeyPress and "pressed" or "released",
+                self.keymap[event.detail]))
         else:
             self.logger.debug('No mapping for scan_code %d' % event.detail)
             return
 
         masks = {
-            1<<0: 'shift',
-            1<<1: 'lock',
-            1<<2: 'ctrl',
-            1<<3: 'alt',
-            1<<4: 'mod2',
-            1<<5: 'mod3',
-            1<<6: 'super',
-            1<<7: 'meta'
+            1 << 0: 'shift',
+            1 << 1: 'lock',
+            1 << 2: 'ctrl',
+            1 << 3: 'alt',
+            1 << 4: 'mod2',
+            1 << 5: 'mod3',
+            1 << 6: 'super',
+            1 << 7: 'meta'
         }
         for k in masks:
             if k & event.state:
@@ -251,11 +252,12 @@ class ListenKbd(threading.Thread):
                     mod = mod + _("Super+")
 
                 if self.cmd_keys['shift']:
-                    if key_shift == key_normal or key_normal == u'\x00' or key_shift == u'\x00':
+                    if (key_shift == key_normal or key_normal == u'\x00'
+                            or key_shift == u'\x00'):
                         mod = mod + _("Shift+")
                     key = key_shift
-                if self.cmd_keys['capslock'] \
-                    and ord(key_normal) in range(97,123):
+                if (self.cmd_keys['capslock'] and
+                        ord(key_normal) in range(97, 123)):
                     key = key_shift
                 if self.cmd_keys['meta']:
                     key = key_dead
@@ -314,4 +316,3 @@ class ListenKbd(threading.Thread):
         self.local_dpy.flush()
         self.record_dpy.record_free_context(self.ctx)
         self.logger.debug("Thread stopped.")
-

--- a/Screenkey/listenkbd.py
+++ b/Screenkey/listenkbd.py
@@ -134,9 +134,9 @@ class ListenKbd(threading.Thread):
         return ""
 
     def replace_xk_key(self, key, keysym):
-        if key == '\x00':
-            return ''
         print(key, keysym)
+        if key == u'\x00' or key == '\x00':
+            return ''
         for name in dir(XK):
             if name[:3] == "XK_" and getattr(XK, name) == keysym:
                 if name in REPLACE_KEYS:
@@ -275,7 +275,7 @@ class ListenKbd(threading.Thread):
                     key = u'\u2623'
 
                 string = self.replace_xk_key(key, keysym)
-                if string:
+                if string is not None:
                     key = string
 
                 if mod != '':

--- a/Screenkey/listenkbd.py
+++ b/Screenkey/listenkbd.py
@@ -167,15 +167,14 @@ class ListenKbd(threading.Thread):
             self.label.emit("text-changed")
 
     def key_press(self, reply):
-
         # FIXME:
         # This is not the most efficient way to detect the
         # use of sudo/gksudo but it works.
         if not self.nosudo:
-            sudo_is_running = subprocess.call(
+            sudo_is_running = 0 == subprocess.call(
                 ['ps', '-C', 'sudo'],
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-            if not sudo_is_running:
+            if sudo_is_running:
                 return
 
         if reply.category != record.FromServer:

--- a/Screenkey/modmap.py
+++ b/Screenkey/modmap.py
@@ -3,12 +3,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Screenkey/modmap.py
+++ b/Screenkey/modmap.py
@@ -16,13 +16,16 @@
 import re
 import subprocess
 
+
 def cmd_keymap_table():
     return subprocess.Popen(
-           ['xmodmap','-pk'], stdout=subprocess.PIPE).communicate()[0]
+        ['xmodmap', '-pk'], stdout=subprocess.PIPE).communicate()[0]
+
 
 def cmd_modifier_map():
     return subprocess.Popen(
-            ['xmodmap','-pm'], stdout=subprocess.PIPE).communicate()[0]
+        ['xmodmap', '-pm'], stdout=subprocess.PIPE).communicate()[0]
+
 
 def get_keymap_table():
     keymap = {}
@@ -49,6 +52,7 @@ def get_keymap_table():
 
     return keymap
 
+
 def get_modifier_map():
     modifiers = []
 
@@ -68,6 +72,7 @@ def get_modifier_map():
 
     return modifiers
 
+
 def keysym_to_unicode(keysym):
     if keysym in mapping:
         return unichr(mapping[keysym])
@@ -76,6 +81,7 @@ def keysym_to_unicode(keysym):
             return unichr(keysym)
         except ValueError:
             return u'\x00'
+
 
 mapping = {
     0x01a1: 0x0104,

--- a/Screenkey/modmap.py
+++ b/Screenkey/modmap.py
@@ -72,7 +72,10 @@ def keysym_to_unicode(keysym):
     if keysym in mapping:
         return unichr(mapping[keysym])
     else:
-        return unichr(keysym)
+        try:
+            return unichr(keysym)
+        except ValueError:
+            return u'\x00'
 
 mapping = {
     0x01a1: 0x0104,

--- a/Screenkey/modmap.py
+++ b/Screenkey/modmap.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2010 Pablo Seminario <pabluk@gmail.com>
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Screenkey/modmap.py
+++ b/Screenkey/modmap.py
@@ -45,7 +45,7 @@ def get_keymap_table():
                         keysym = '0x0'
                     new_keysyms.append(keysym_to_unicode(int(keysym, 16)))
 
-    		keymap[keycode] = new_keysyms
+                keymap[keycode] = new_keysyms
 
     return keymap
 

--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -39,22 +39,23 @@ SIZE_SMALL = 2
 MODE_RAW = 0
 MODE_NORMAL = 1
 
+
 class Screenkey(gtk.Window):
 
     POSITIONS = {
-        POS_TOP:_('Top'),
-        POS_CENTER:_('Center'),
-        POS_BOTTOM:_('Bottom'),
-        POS_KEEP:_('Keep'),
+        POS_TOP: _('Top'),
+        POS_CENTER: _('Center'),
+        POS_BOTTOM: _('Bottom'),
+        POS_KEEP: _('Keep'),
     }
     SIZES = {
-        SIZE_LARGE:_('Large'),
-        SIZE_MEDIUM:_('Medium'),
-        SIZE_SMALL:_('Small'),
+        SIZE_LARGE: _('Large'),
+        SIZE_MEDIUM: _('Medium'),
+        SIZE_SMALL: _('Small'),
     }
     MODES = {
-        MODE_RAW:_('Raw'),
-        MODE_NORMAL:_('Normal'),
+        MODE_RAW: _('Raw'),
+        MODE_NORMAL: _('Normal'),
     }
 
     STATE_FILE = os.path.join(glib.get_user_cache_dir(),
@@ -96,7 +97,7 @@ class Screenkey(gtk.Window):
         self.pos_y = 0
 
         gobject.signal_new("text-changed", gtk.Label,
-                        gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
+                           gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
         self.label = gtk.Label()
         self.label.set_justify(gtk.JUSTIFY_RIGHT)
         self.label.set_ellipsize(pango.ELLIPSIZE_START)
@@ -116,10 +117,11 @@ class Screenkey(gtk.Window):
             other_win_pos = self.get_window_pos(window_id)
 
             window_width, window_height = self.set_window_size_of_other_win(
-                    other_win_pos, self.options['size'])
+                other_win_pos, self.options['size'])
 
-            self.set_xy_position_of_other_win(other_win_pos, self.options['position'],
-                    window_width, window_height)
+            self.set_xy_position_of_other_win(
+                other_win_pos, self.options['position'],
+                window_width, window_height)
 
         self.nosudo = nosudo
 
@@ -127,7 +129,6 @@ class Screenkey(gtk.Window):
                                    mode=self.options['mode'],
                                    nosudo=self.nosudo)
         self.listenkbd.start()
-
 
         menu = gtk.Menu()
 
@@ -141,7 +142,6 @@ class Screenkey(gtk.Window):
         preferences_item.connect("activate", self.on_preferences_dialog)
         preferences_item.show()
         menu.append(preferences_item)
-
 
         about_item = gtk.ImageMenuItem(gtk.STOCK_ABOUT)
         about_item.connect("activate", self.on_about_dialog)
@@ -160,23 +160,22 @@ class Screenkey(gtk.Window):
 
         try:
             import appindicator
-            self.systray = appindicator.Indicator(APP_NAME,
-                           'indicator-messages',
-                            appindicator.CATEGORY_APPLICATION_STATUS)
+            self.systray = appindicator.Indicator(
+                APP_NAME,
+                'indicator-messages',
+                appindicator.CATEGORY_APPLICATION_STATUS)
             self.systray.set_status(appindicator.STATUS_ACTIVE)
             self.systray.set_attention_icon("indicator-messages-new")
-            self.systray.set_icon(
-                    "preferences-desktop-keyboard-shortcuts")
+            self.systray.set_icon("preferences-desktop-keyboard-shortcuts")
             self.systray.set_menu(menu)
             self.logger.debug("Using AppIndicator.")
-        except(ImportError):
+        except ImportError:
             self.systray = gtk.StatusIcon()
             self.systray.set_from_icon_name(
-                    "preferences-desktop-keyboard-shortcuts")
+                "preferences-desktop-keyboard-shortcuts")
             self.systray.connect("popup-menu",
-                    self.on_statusicon_popup, menu)
+                                 self.on_statusicon_popup, menu)
             self.logger.debug("Using StatusIcon.")
-
 
         self.connect("destroy-event", self.quit)
         self.connect("delete-event", self.quit)
@@ -252,7 +251,7 @@ class Screenkey(gtk.Window):
         """ get window position x,y and size width, height" """
         p = Popen(["xwininfo", "-id", win_id], stdout=PIPE)
         out = p.communicate()[0]
-        #if p.returncode != 0:
+        # if p.returncode != 0:
         x = int(re.search("Absolute upper-left X:.*?(\d+)", out).groups()[0])
         y = int(re.search("Absolute upper-left Y:.*?(\d+)", out).groups()[0])
         width = int(re.search("Width:.*?(\d+)", out).groups()[0])
@@ -261,7 +260,7 @@ class Screenkey(gtk.Window):
         return {'x': x, 'y': y, 'width': width, 'height': height}
 
     def set_xy_position_of_other_win(self, window_pos, setting,
-            window_width, window_height):
+                                     window_width, window_height):
         """Set window position."""
 
         if setting == POS_TOP:
@@ -270,8 +269,8 @@ class Screenkey(gtk.Window):
             self.move(0, self.screen_height / 2)
         if setting == POS_BOTTOM:
             self.move(window_pos['x']+window_pos['width']-window_width,
-                    int(window_pos['y'] + window_pos['height'] - \
-                            window_height*5 - window_pos['height']*0.05))
+                      int(window_pos['y'] + window_pos['height'] -
+                          window_height*5 - window_pos['height']*0.05))
         if setting == POS_KEEP:
             self.move(self.pos_x, self.pos_y)
 
@@ -340,7 +339,8 @@ class Screenkey(gtk.Window):
         attr.change(pango.AttrWeight(pango.WEIGHT_BOLD, 0, -1))
 
         fgcolor = gtk.gdk.color_parse(self.fg)
-        attr.change(pango.AttrForeground(fgcolor.red, fgcolor.green, fgcolor.blue, 0, -1))
+        attr.change(pango.AttrForeground(
+            fgcolor.red, fgcolor.green, fgcolor.blue, 0, -1))
 
         self.pos_x = event.x
         self.pos_y = event.y
@@ -355,8 +355,8 @@ class Screenkey(gtk.Window):
 
     def on_preferences_dialog(self, widget, data=None):
         prefs = gtk.Dialog(APP_NAME, None,
-                    gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
-                    (gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE))
+                           gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
+                           (gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE))
 
         def on_sb_time_changed(widget, data=None):
             self.options['timeout'] = widget.get_value()
@@ -491,13 +491,11 @@ class Screenkey(gtk.Window):
         about.set_copyright(u"2010 \u00a9 %s" % AUTHOR)
         about.set_comments(APP_DESC)
         about.set_documenters(
-                [u"Jos\xe9 Mar\xeda Quiroga <pepelandia@gmail.com>"]
+            [u"Jos\xe9 Mar\xeda Quiroga <pepelandia@gmail.com>"]
         )
         about.set_website(APP_URL)
         about.set_icon_name('preferences-desktop-keyboard-shortcuts')
-        about.set_logo_icon_name(
-                'preferences-desktop-keyboard-shortcuts'
-        )
+        about.set_logo_icon_name('preferences-desktop-keyboard-shortcuts')
         about.run()
         about.destroy()
 
@@ -508,4 +506,3 @@ class Screenkey(gtk.Window):
             os._exit(0)
 
         os.setsid()
-

--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -3,12 +3,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -57,7 +57,7 @@ class Screenkey(gtk.Window):
         MODE_NORMAL:_('Normal'),
     }
 
-    STATE_FILE = os.path.join(glib.get_user_cache_dir(), 
+    STATE_FILE = os.path.join(glib.get_user_cache_dir(),
                               'screenkey.dat')
 
     def __init__(self, logger, nodetach, nohide, bg, fg, nosudo, window_id):
@@ -95,7 +95,7 @@ class Screenkey(gtk.Window):
         self.pos_x = 0
         self.pos_y = 0
 
-        gobject.signal_new("text-changed", gtk.Label, 
+        gobject.signal_new("text-changed", gtk.Label,
                         gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
         self.label = gtk.Label()
         self.label.set_justify(gtk.JUSTIFY_RIGHT)
@@ -104,8 +104,8 @@ class Screenkey(gtk.Window):
         self.label.show()
         self.add(self.label)
 
-        self.screen_width = gtk.gdk.screen_width()   
-        self.screen_height = gtk.gdk.screen_height() 
+        self.screen_width = gtk.gdk.screen_width()
+        self.screen_height = gtk.gdk.screen_height()
 
         self.set_gravity(gtk.gdk.GRAVITY_CENTER)
 
@@ -118,12 +118,12 @@ class Screenkey(gtk.Window):
             window_width, window_height = self.set_window_size_of_other_win(
                     other_win_pos, self.options['size'])
 
-            self.set_xy_position_of_other_win(other_win_pos, self.options['position'], 
+            self.set_xy_position_of_other_win(other_win_pos, self.options['position'],
                     window_width, window_height)
 
         self.nosudo = nosudo
 
-        self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+        self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                    mode=self.options['mode'],
                                    nosudo=self.nosudo)
         self.listenkbd.start()
@@ -160,8 +160,8 @@ class Screenkey(gtk.Window):
 
         try:
             import appindicator
-            self.systray = appindicator.Indicator(APP_NAME, 
-                           'indicator-messages', 
+            self.systray = appindicator.Indicator(APP_NAME,
+                           'indicator-messages',
                             appindicator.CATEGORY_APPLICATION_STATUS)
             self.systray.set_status(appindicator.STATUS_ACTIVE)
             self.systray.set_attention_icon("indicator-messages-new")
@@ -173,7 +173,7 @@ class Screenkey(gtk.Window):
             self.systray = gtk.StatusIcon()
             self.systray.set_from_icon_name(
                     "preferences-desktop-keyboard-shortcuts")
-            self.systray.connect("popup-menu", 
+            self.systray.connect("popup-menu",
                     self.on_statusicon_popup, menu)
             self.logger.debug("Using StatusIcon.")
 
@@ -203,7 +203,7 @@ class Screenkey(gtk.Window):
             except:
                 f.close()
         except IOError:
-            self.logger.debug("file %s does not exists." % 
+            self.logger.debug("file %s does not exists." %
                               self.STATE_FILE)
         return options
 
@@ -269,7 +269,7 @@ class Screenkey(gtk.Window):
         if setting == POS_CENTER:
             self.move(0, self.screen_height / 2)
         if setting == POS_BOTTOM:
-            self.move(window_pos['x']+window_pos['width']-window_width, 
+            self.move(window_pos['x']+window_pos['width']-window_width,
                     int(window_pos['y'] + window_pos['height'] - \
                             window_height*5 - window_pos['height']*0.05))
         if setting == POS_KEEP:
@@ -291,7 +291,7 @@ class Screenkey(gtk.Window):
         if button == 3:
             if data:
                 data.show()
-                data.popup(None, None, gtk.status_icon_position_menu, 
+                data.popup(None, None, gtk.status_icon_position_menu,
                            3, timestamp, widget)
 
     def on_label_change(self, widget, data=None):
@@ -316,14 +316,14 @@ class Screenkey(gtk.Window):
 
     def on_change_mode(self, mode):
         self.listenkbd.stop()
-        self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+        self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                    mode=mode, nosudo=self.nosudo)
         self.listenkbd.start()
 
     def on_show_keys(self, widget, data=None):
         if widget.get_active():
             self.logger.debug("Screenkey enabled.")
-            self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+            self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                        mode=self.options['mode'],
                                        nosudo=self.nosudo)
             self.listenkbd.start()
@@ -354,8 +354,8 @@ class Screenkey(gtk.Window):
         self.label.set_attributes(attr)
 
     def on_preferences_dialog(self, widget, data=None):
-        prefs = gtk.Dialog(APP_NAME, None, 
-                    gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT, 
+        prefs = gtk.Dialog(APP_NAME, None,
+                    gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
                     (gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE))
 
         def on_sb_time_changed(widget, data=None):
@@ -401,11 +401,11 @@ class Screenkey(gtk.Window):
         sb_time.set_update_policy(gtk.UPDATE_IF_VALID)
         sb_time.set_value(self.options['timeout'])
         sb_time.connect("value-changed", on_sb_time_changed)
-        hbox_time.pack_start(lbl_time1, expand=False, 
+        hbox_time.pack_start(lbl_time1, expand=False,
                              fill=False, padding=6)
-        hbox_time.pack_start(sb_time, expand=False, 
+        hbox_time.pack_start(sb_time, expand=False,
                              fill=False, padding=4)
-        hbox_time.pack_start(lbl_time2, expand=False, 
+        hbox_time.pack_start(lbl_time2, expand=False,
                              fill=False, padding=4)
         frm_time.add(hbox_time)
         frm_time.show_all()
@@ -426,9 +426,9 @@ class Screenkey(gtk.Window):
         cbox_positions.set_active(self.options['position'])
         cbox_positions.connect("changed", on_cbox_changed)
 
-        hbox1_aspect.pack_start(lbl_positions, expand=False, 
+        hbox1_aspect.pack_start(lbl_positions, expand=False,
                                 fill=False, padding=6)
-        hbox1_aspect.pack_start(cbox_positions, expand=False, 
+        hbox1_aspect.pack_start(cbox_positions, expand=False,
                                 fill=False, padding=4)
 
         hbox2_aspect = gtk.HBox()
@@ -441,9 +441,9 @@ class Screenkey(gtk.Window):
         cbox_sizes.set_active(self.options['size'])
         cbox_sizes.connect("changed", on_cbox_sizes_changed)
 
-        hbox2_aspect.pack_start(lbl_sizes, expand=False, 
+        hbox2_aspect.pack_start(lbl_sizes, expand=False,
                                 fill=False, padding=6)
-        hbox2_aspect.pack_start(cbox_sizes, expand=False, 
+        hbox2_aspect.pack_start(cbox_sizes, expand=False,
                                 fill=False, padding=4)
 
         vbox_aspect.pack_start(hbox1_aspect)
@@ -462,9 +462,9 @@ class Screenkey(gtk.Window):
             cbox_modes.insert_text(key, value)
         cbox_modes.set_active(self.options['mode'])
         cbox_modes.connect("changed", on_cbox_modes_changed)
-        hbox_kbd.pack_start(lbl_kbd, expand=False, 
+        hbox_kbd.pack_start(lbl_kbd, expand=False,
                             fill=False, padding=6)
-        hbox_kbd.pack_start(cbox_modes, expand=False, 
+        hbox_kbd.pack_start(cbox_modes, expand=False,
                             fill=False, padding=4)
         frm_kbd.add(hbox_kbd)
 

--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -500,8 +500,7 @@ class Screenkey(gtk.Window):
         about.destroy()
 
     def drop_tty(self):
-        # We fork and setsid so that we drop the controlling
-        # tty.
+        # We fork and setsid so that we drop the controlling tty.
         if os.fork() != 0:
             os._exit(0)
 

--- a/screenkey
+++ b/screenkey
@@ -29,25 +29,32 @@ gettext.install('screenkey', unicode=True)
 from Screenkey import APP_NAME, APP_DESC, VERSION
 from Screenkey.screenkey import Screenkey
 
-gtk.gdk.threads_init()
 
-def Main():
+def main():
     parser = OptionParser(description=APP_DESC, version=VERSION)
-    parser.add_option("--no-detach", action="store_true",
-        dest="nodetach", default=False,
+    parser.add_option(
+        "--no-detach", action="store_true",
+        dest="nodetach", default=True,
         help=_("do not detach from the parent"))
-    parser.add_option("-d", "--debug", action="store_true",
+    parser.add_option(
+        "-d", "--debug", action="store_true",
         dest="debug", default=False, help=_("show debug information"))
-    parser.add_option("-n", "--no-hide", action="store_true",
+    parser.add_option(
+        "-n", "--no-hide", action="store_true",
         dest="nohide", default=False, help=_("do not hide"))
-    parser.add_option("--bg", action="store",
-        dest="bg", default="black", help=_("background color (in #RRGGBB format)"))
-    parser.add_option("--fg", action="store",
+    parser.add_option(
+        "--bg", action="store",
+        dest="bg", default="black",
+        help=_("background color (in #RRGGBB format)"))
+    parser.add_option(
+        "--fg", action="store",
         dest="fg", default="white", help=_("foreground color"))
-    parser.add_option("--no-sudo", action="store_true",
+    parser.add_option(
+        "--no-sudo", action="store_true",
         dest="nosudo", default="white",
         help=_("do not perform very expensive sudo running check"))
-    parser.add_option("-w", "--window",
+    parser.add_option(
+        "-w", "--window",
         dest="window_id", default=0, help=_("align to other window"))
     (options, args) = parser.parse_args()
 
@@ -68,7 +75,11 @@ def Main():
         logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(APP_NAME)
 
-    s = Screenkey(logger=logger, nodetach=options.nodetach,
+    gtk.gdk.threads_init()
+
+    s = Screenkey(
+        logger=logger,
+        nodetach=options.nodetach,
         nohide=options.nohide,
         bg=options.bg, fg=options.fg,
         nosudo=options.nosudo,
@@ -81,5 +92,4 @@ def Main():
             os.system('kill %d' % (os.getpid()))
 
 if __name__ == "__main__":
-    Main()
-
+    main()

--- a/screenkey
+++ b/screenkey
@@ -51,7 +51,7 @@ def main():
         dest="fg", default="white", help=_("foreground color"))
     parser.add_option(
         "--no-sudo", action="store_true",
-        dest="nosudo", default="white",
+        dest="nosudo", default=True,
         help=_("do not perform very expensive sudo running check"))
     parser.add_option(
         "-w", "--window",

--- a/screenkey
+++ b/screenkey
@@ -4,12 +4,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -33,10 +33,10 @@ gtk.gdk.threads_init()
 
 def Main():
     parser = OptionParser(description=APP_DESC, version=VERSION)
-    parser.add_option("--no-detach", action="store_true", 
-        dest="nodetach", default=False, 
+    parser.add_option("--no-detach", action="store_true",
+        dest="nodetach", default=False,
         help=_("do not detach from the parent"))
-    parser.add_option("-d", "--debug", action="store_true", 
+    parser.add_option("-d", "--debug", action="store_true",
         dest="debug", default=False, help=_("show debug information"))
     parser.add_option("-n", "--no-hide", action="store_true",
         dest="nohide", default=False, help=_("do not hide"))
@@ -56,7 +56,7 @@ def Main():
             # Send debug messages to standard output
             logfile = None
         else:
-            logfile = os.path.join(os.path.expanduser('~'), 
+            logfile = os.path.join(os.path.expanduser('~'),
                                    '.screenkey.log')
             username = os.environ.get('SUDO_USER')
             if username:


### PR DESCRIPTION
Fixing unicode error upon launch (also fixed in elecnix/screenkey@5c362f2aabd80011d9c518a978483ce3332b22a2, but using a different logic).

Other minor cleanup, mostly whitespace (add `?w=1` to GitHub URLs to ignore whitespace when viewing the diffs) and [code styling](https://www.python.org/dev/peps/pep-0008/) (with help of [pep8 tool](https://pypi.python.org/pypi/pep8)).
